### PR TITLE
feat: add utility functions for normalizing tool argument values

### DIFF
--- a/src/common/AutoModel/modeling_lfm2.cpp
+++ b/src/common/AutoModel/modeling_lfm2.cpp
@@ -7,6 +7,7 @@
 
 #include "AutoModel/modeling_lfm2.hpp"
 #include "utils/utils.hpp"
+#include "utils/tool_calling_utils.hpp"
 #include "metrices.hpp"
 
 /************              LFM2 family            **************/
@@ -226,12 +227,7 @@ StreamResult LFM2::parse_stream_content(const std::string content) {
                             value_end++;
                         }
                         value = args_part.substr(pos, value_end - pos);
-                        size_t v_start = value.find_first_not_of(" \t\n\r");
-                        size_t v_end = value.find_last_not_of(" \t\n\r");
-                        if (v_start != std::string::npos) {
-                            value = value.substr(v_start, v_end - v_start + 1);
-                        }
-                        args_json[key] = value;
+                        args_json[key] = normalize_tool_argument_value(value);
                         pos = value_end;
                     }
                 }
@@ -516,12 +512,7 @@ StreamResult LFM2_5_TK::parse_stream_content(const std::string content) {
                             value_end++;
                         }
                         value = args_part.substr(pos, value_end - pos);
-                        size_t v_start = value.find_first_not_of(" \t\n\r");
-                        size_t v_end = value.find_last_not_of(" \t\n\r");
-                        if (v_start != std::string::npos) {
-                            value = value.substr(v_start, v_end - v_start + 1);
-                        }
-                        args_json[key] = value;
+                        args_json[key] = normalize_tool_argument_value(value);
                         pos = value_end;
                     }
                 }

--- a/src/include/utils/tool_calling_utils.hpp
+++ b/src/include/utils/tool_calling_utils.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cctype>
+#include <cstdlib>
+#include <string>
+#include <nlohmann/json.hpp>
+
+inline std::string trim_tool_argument_token(const std::string& text) {
+    size_t start = 0;
+    while (start < text.size() && std::isspace(static_cast<unsigned char>(text[start]))) {
+        start++;
+    }
+
+    size_t end = text.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(text[end - 1]))) {
+        end--;
+    }
+
+    return text.substr(start, end - start);
+}
+
+inline nlohmann::ordered_json normalize_tool_argument_value(const std::string& value_text) {
+    std::string trimmed = trim_tool_argument_token(value_text);
+    if (trimmed.empty()) {
+        return "";
+    }
+
+    if (trimmed.size() >= 2 && trimmed.front() == '\'' && trimmed.back() == '\'') {
+        return trimmed.substr(1, trimmed.size() - 2);
+    }
+
+    try {
+        return nlohmann::ordered_json::parse(trimmed);
+    }
+    catch (...) {
+        return trimmed;
+    }
+}
+
+inline nlohmann::ordered_json normalize_tool_arguments(const std::string& arguments_text) {
+    try {
+        return nlohmann::ordered_json::parse(arguments_text);
+    }
+    catch (...) {
+        return arguments_text;
+    }
+}


### PR DESCRIPTION
### Description

**Overview**

This PR introduces a new utility module for standardizing tool argument processing in LFM2 and LFM2_5_TK models. 

The change extracts repetitive argument normalization logic into reusable, well-tested functions that improve code clarity and extensibility.

---

The same issue was also found in qwen, and it needs to be confirmed whether the current fix is ​​feasible.