### PR TITLE
whisper: don't force a timestamp after 16 tokens — truncated every transcription (#698)

### DIFF
--- a/src/common/whisper/modeling_whisper.cpp
+++ b/src/common/whisper/modeling_whisper.cpp
@@ -182,7 +182,11 @@ std::pair<std::string, std::string> Whisper::generate(whisper_task_type_t task, 
             os << token_str << std::flush;
         }
         
-        int watching_dog = 16;
+        // Forcing a timestamp after only 16 content tokens (~4 s of speech) makes
+        // Whisper close the segment and emit EOT: every transcription was cut at
+        // ~15 tokens (see issue #698). 448 = decoder max, so the guard only fires
+        // on a genuinely runaway decode.
+        int watching_dog = 448;
         for (int i = 0; i < 448 - 3; i++){
             buffer<bf16> logits = this->whisper_engine->decode_audio(last_idx);
             if (watching_dog == 0 && allow_force_time_stamp){


### PR DESCRIPTION
Fixes #698.

## What happens
After 16 content tokens without a timestamp, the decode loop in `Whisper::generate()` force-samples a timestamp token (`watching_dog`). Whisper treats that as end-of-segment and emits EOT, so **any continuous speech longer than ~4 s comes back cut at ~15 tokens** — on Linux the `/v1/audio/transcriptions` endpoint returned the same 50-character prefix for 3.2 s, 5 s and 7.3 s clips alike, regardless of `response_format`, `language` or `--ctx-len`.

Reproduced on the 1.0.3 Linux release **and** on a from-source build of `main` (Ryzen AI MAX+ 395 / NPU2, FW 1.1.2.65, amdxdna 0.6, kernel 7.0.8).

## The change
Raise the watchdog from 16 to the decoder maximum (448), so the guard only fires on a genuinely runaway decode. One line plus a comment.

Verified on device with the same 7.3 s Italian clip:

| | chars | text |
|---|---|---|
| before | 50 | `Domani alle 9 accendi le luci del soggiorno e ric` |
| after | 115 | `Domani alle 9 accendi le luci del soggiorno e ricordami di comprare il latte e le uova al supermercato e se lunga.` |

5.0 s per transcription on NPU2, output matches whisper.cpp on GPU for the same clip.

If you'd rather keep a tighter guard, an alternative is to only force a timestamp when the model has produced no content tokens either, or to make the threshold configurable — happy to rework it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEsCw8PTJjca1mUwu6jMzX